### PR TITLE
fix datagen warning

### DIFF
--- a/src/main/java/com/aitextras/client/renderers/monitors/ExtrasScreenMonitorRenderer.java
+++ b/src/main/java/com/aitextras/client/renderers/monitors/ExtrasScreenMonitorRenderer.java
@@ -132,7 +132,7 @@ public class ExtrasScreenMonitorRenderer<T extends ExtrasScreenMonitorBlockEntit
         this.textRenderer.drawWithOutline(Text.of(name).asOrderedText(), 150 - (this.textRenderer.getWidth(name)), 78,
                 0xFFFFFF, 0x000000, matrices.peek().getPositionMatrix(), vertexConsumers, 0xF000F0);
 
-       if (tardis.alarm().enabled().get())
+       if (tardis.alarm().isEnabled())
            this.textRenderer.drawWithOutline(Text.of("⚠").asOrderedText(), 140, 0, 0xFE0000, 0x000000,
                    matrices.peek().getPositionMatrix(), vertexConsumers, 0xF000F0);
 


### PR DESCRIPTION
Removes the warning about a deprecated call by replacing it with the new method that does the same as the old.