### PR TITLE
fix some dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,24 +69,16 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     include(implementation "net.objecthunter:exp4j:0.4.8")
-    include(modApi("dev.drtheo:multidim:${project.multidim_version}")) {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
-    include(modImplementation("dev.drtheo:scheduler:${project.scheduler_version}")) {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
-    include(modImplementation("dev.drtheo:queue:${project.queue_version}")) {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
+    modImplementation "dev.drtheo:multidim:${project.multidim_version}"
+    modImplementation "dev.drtheo:scheduler:${project.scheduler_version}"
+    modImplementation "dev.drtheo:queue:${project.queue_version}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "com.github.amblelabs:ait:${project.ait_version}"
     modImplementation "dev.isxander:yet-another-config-lib:${project.yacl_version}"
 
-    modApi("com.github.amblelabs:modkit:v${project.amblekit_version}") {
-        exclude(group: "net.fabricmc.fabric-api")
-    }
+    modImplementation("com.github.amblelabs:modkit:v${project.amblekit_version}")
 }
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@ archives_base_name = ait-extras
 	# check this on https://modmuss50.me/fabric.html
 fabric_version=0.92.3+1.20.1
 ait_version= 6c2922e3d2
-modmenu_version=7.0.1
 yacl_version=3.6.1+1.20.1-fabric
 multidim_version = 2.1.4
 scheduler_version = 1.1.0


### PR DESCRIPTION
This prevents the multidim, scheduler and queue dependencies from unnecessarily being included in the jar.
It also makes them and the modkit dependency non-transitive.

I also removed the obsolete version string for mod menu.